### PR TITLE
Fix a small bug when no processes are found

### DIFF
--- a/lib/sidekiq/prometheus/exporter/standard.rb
+++ b/lib/sidekiq/prometheus/exporter/standard.rb
@@ -46,7 +46,7 @@ module Sidekiq
         end
 
         def total_workers
-          Sidekiq::ProcessSet.new.map { |process| process['concurrency'] }.reduce(:+)
+          Sidekiq::ProcessSet.new.map { |process| process['concurrency'] }.reduce(:+).to_i
         end
       end
     end


### PR DESCRIPTION
When no processes are found by `Sidekiq::ProcessSet` the `#total_workers` method returned nil which causes a `TypeError: can't convert nil into Integer` exception in the erb template.